### PR TITLE
Fix sprintf warning

### DIFF
--- a/gmi100.c
+++ b/gmi100.c
@@ -7,7 +7,7 @@
 #define WARN(msg) do { fputs("WARNING: "msg"\n", stderr); goto start; } while(0)
 
 int main(int argc, char **argv) {
-        char uri[1024+1], buf[1024+1], buf2[1024+1], *bp, *t=tmpnam(0);
+        char uri[1024+1], buf[2*(1024+1)], buf2[1024+1], *bp, *t=tmpnam(0);
         int i, j, siz, sfd=0, hp, KB=1024;
         FILE *his, *tmp;
         struct hostent *he;

--- a/gmi100.c
+++ b/gmi100.c
@@ -7,7 +7,7 @@
 #define WARN(msg) do { fputs("WARNING: "msg"\n", stderr); goto start; } while(0)
 
 int main(int argc, char **argv) {
-        char uri[1024+1], buf[2*(1024+1)], buf2[1024+1], *bp, *t=tmpnam(0);
+        char uri[1024+1], buf[4096], buf2[2048], *bp, *t=tmpnam(0);
         int i, j, siz, sfd=0, hp, KB=1024;
         FILE *his, *tmp;
         struct hostent *he;


### PR DESCRIPTION
With gcc version 14.2.1 I got the following warning:

```
gmi100.c:51:33: warning: ‘%s’ directive writing up to 1024 bytes into a region of size between 1 and 1025 [-Wformat-overflow=]
   51 |                 sprintf(buf, "%s%s", uri, bp);
      |                                 ^~
gmi100.c:51:17: note: ‘sprintf’ output between 1 and 2049 bytes into a
destination of size 1025
   51 |                 sprintf(buf, "%s%s", uri, bp);
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
Uri and bp point to two character arrays of size 1025 both, thus the destination should be twice larger.